### PR TITLE
Add Swift Sneak tomes

### DIFF
--- a/src/main/kotlin/io/sc3/goodies/tomes/TomeEnchantments.kt
+++ b/src/main/kotlin/io/sc3/goodies/tomes/TomeEnchantments.kt
@@ -34,6 +34,7 @@ private const val UPGRADE_COST_MAXED = 30
 object TomeEnchantments {
   val validEnchantments = listOf(
     FEATHER_FALLING,
+    SWIFT_SNEAK,
     THORNS,
     SHARPNESS,
     SMITE,


### PR DESCRIPTION
I think Swift Sneak would be a good candidate for ancient tomes in 1.19+. [According to the Minecraft wiki](https://minecraft.fandom.com/wiki/Swift_Sneak) this will make sneaking speed go from 75% of walking speed to 90% of walking speed.