### PR TITLE
fix: shulker box item count only showing up to 27

### DIFF
--- a/src/main/kotlin/io/sc3/goodies/ironshulker/IronShulkerBlock.kt
+++ b/src/main/kotlin/io/sc3/goodies/ironshulker/IronShulkerBlock.kt
@@ -180,7 +180,7 @@ class IronShulkerBlock(
     }
 
     if (nbt.contains("Items", LIST)) {
-      val inv = DefaultedList.ofSize(27, ItemStack.EMPTY)
+      val inv = DefaultedList.ofSize(this.variant.size, ItemStack.EMPTY)
       Inventories.readNbt(nbt, inv)
 
       var shownStacks = 0


### PR DESCRIPTION
This PR fixes a problem with Iron, Gold and Diamond shulker box tooltips showing only up to "and 22 more..." in their tooltip, and allows them to show their actual stacks remaining. 

Behavior prior to patch:
![image](https://user-images.githubusercontent.com/28579437/214952793-cdfa6499-9450-49a2-b319-44be772cbd50.png)

Behavior with patch:
![image](https://user-images.githubusercontent.com/28579437/214952947-c4fc91ff-c329-4d2f-aaa1-eb0f5f4c8b57.png)
