### PR TITLE
fix: correctly compare items for magnet inventory check (closes #5)

### DIFF
--- a/src/main/kotlin/io/sc3/goodies/itemmagnet/ItemMagnetItem.kt
+++ b/src/main/kotlin/io/sc3/goodies/itemmagnet/ItemMagnetItem.kt
@@ -111,7 +111,7 @@ class ItemMagnetItem(settings: Settings) : TrinketItem(settings) {
       }
 
       // Ensure there is space in the inventory for the item
-      if (player.inventory.main.none { it.isEmpty || it.isItemEqual(stack) && it.count < it.maxCount }) {
+      if (player.inventory.main.none { it.isEmpty || ItemStack.canCombine(it, stack) && it.count < it.maxCount }) {
         continue
       }
 


### PR DESCRIPTION
This switches to using the static method ItemStack.canCombine for checking whether an item on the ground can stack with an item in the inventory. This prevents an issue where an item continually follows a player because the magnet is attempting to pull it into a full inventory which has the same item with different NBT.

(I tested this with a few other stackable NBT items, but not actual 3D prints, since I did not want to go through the effort of getting `./gradlew runClient` to include sc-peripherals as well)